### PR TITLE
change style of done/disabled category buttons

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -243,17 +243,16 @@ button:only-of-type {
 }
 
 button[disabled] {
-  opacity: 0.7;
+  background: #0a8f60;
+  color: #6fe9bf;
 }
 
-button[disabled]::after {
-  content: ' (done)';
-  font-size: 0.8em;
+button[disabled]::before {
+  content: '\0020\2713';
+  padding-right: 0.25em;
+  font-weight: bold;
 }
 
-button[disabled]:active {
-  background: #E25C43;
-}
 /* links
 ---------------------------------------------*/
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -247,8 +247,9 @@ button[disabled] {
   color: #6fe9bf;
 }
 
-button[disabled]::before {
-  content: '\0020\2713';
+button[disabled]::after {
+  content: ' (done)';
+  font-size: 0.8em;
   padding-right: 0.25em;
   font-weight: bold;
 }


### PR DESCRIPTION
I flicked the helioscissor scanner and came back with this. Tried a few different styles and this one is by far the best as it gives the impression the button has been pressed in.

![screenshot from 2016-01-13 13 59 40](https://cloud.githubusercontent.com/assets/6770091/12296537/44c0801a-ba00-11e5-9bcd-498fdea97cfd.png)
