### PR TITLE
Update broken links due to rebrand

### DIFF
--- a/src/privacy.html
+++ b/src/privacy.html
@@ -189,9 +189,9 @@
     <div class="footer-container">
       <div class="social-profile-buttons">
         <ul>
-          <li><a class="facebook" href="http://www.facebook.com/seap.org.uk" target="_blank" rel="noopener"></a></li>
-          <li><a class="twitter" href="https://twitter.com/seapadvocacy" target="_blank" rel="noopener"></a></li>
-          <li><a class="linkedin" href="https://www.linkedin.com/company/seap-uk-" target="_blank" rel="noopener"></a></li>
+          <li><a class="facebook" href="http://www.facebook.com/theadvocacypeople.org.uk" target="_blank" rel="noopener"></a></li>
+          <li><a class="twitter" href="https://twitter.com/advocacypeople" target="_blank" rel="noopener"></a></li>
+          <li><a class="linkedin" href="https://www.linkedin.com/company/the-advocacy-people1" target="_blank" rel="noopener"></a></li>
         </ul>
       </div>
     </div>

--- a/src/template.html
+++ b/src/template.html
@@ -14,8 +14,8 @@
     <meta property="og:url" content="http://c-app.org.uk/" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:url" content="http://c-app.org.uk/" />
-    <meta name="twitter:site" content="@seapadvocacy" />
-    <meta name="twitter:creator" content="@seapadvocacy" />
+    <meta name="twitter:site" content="@advocacypeople" />
+    <meta name="twitter:creator" content="@advocacypeople" />
     <meta name="twitter:title" content="c-App" />
     <meta name="twitter:description"
         content="C-App is designed to help people with disabilities or long term physical or mental health conditions to apply for two benefits, Personal Independence Payment (PIP) and Employment and Support Allowance (ESA)." />
@@ -64,7 +64,7 @@
         <div class="donation-banner center">
             <p class="center">If you find this website useful, please donate to help us keep it relevant and running.
             </p>
-            <a href="https://www.justgiving.com/s-e-a-p" target="_blank" rel="noopener noreferrer"
+            <a href="https://www.justgiving.com/theadvocacypeople" target="_blank" rel="noopener noreferrer"
                 class="button-shaped">Donate</a>
         </div>
 
@@ -123,11 +123,11 @@
         <div class="footer-container">
             <div class="social-profile-buttons">
                 <ul>
-                    <li><a class="facebook" href="http://www.facebook.com/seap.org.uk" target="_blank"
+                    <li><a class="facebook" href="http://www.facebook.com/theadvocacypeople.org.uk" target="_blank"
                             rel="noopener"></a></li>
-                    <li><a class="twitter" href="https://twitter.com/seapadvocacy" target="_blank" rel="noopener"></a>
+                    <li><a class="twitter" href="https://twitter.com/advocacypeople" target="_blank" rel="noopener"></a>
                     </li>
-                    <li><a class="linkedin" href="https://www.linkedin.com/company/seap-uk-" target="_blank"
+                    <li><a class="linkedin" href="https://www.linkedin.com/company/the-advocacy-people1" target="_blank"
                             rel="noopener"></a></li>
                 </ul>
             </div>


### PR DESCRIPTION
fixes #116 

Following a rebrand to The Advocacy People - some key links were broken

This does not rebrand, nor fix every link / reference to old seAp references. It is intended as an emergency patch.